### PR TITLE
pmctl: Allow to view swap-devices

### DIFF
--- a/cmd/pmctl/pmctl.go
+++ b/cmd/pmctl/pmctl.go
@@ -346,10 +346,20 @@ func main() {
 						{
 							Name:        "disk-usage",
 							UsageText:   "disk-usage",
-							Description: "Show disk diskusage info",
+							Description: "Show disk disk usage info",
 
 							Action: func(c *cli.Context) error {
 								acquireProcDiskUsage(c.String("url"), token)
+								return nil
+							},
+						},
+						{
+							Name:        "swap-devices",
+							UsageText:   "swap-devices",
+							Description: "Show swap devices",
+
+							Action: func(c *cli.Context) error {
+								acquireProcSwapDevices(c.String("url"), token)
 								return nil
 							},
 						},

--- a/cmd/pmctl/pmctl_proc.go
+++ b/cmd/pmctl/pmctl_proc.go
@@ -398,3 +398,30 @@ func acquireProcDiskUsage(host string, token map[string]string) {
 		fmt.Printf("%v\n", color.HiBlueString(string(jsonData)))
 	}
 }
+
+
+func acquireProcSwapDevices(host string, token map[string]string) {
+	resp, err := web.DispatchSocket(http.MethodGet, host, "/api/v1/proc/swapdevices", token, nil)
+	if err != nil {
+		fmt.Printf("Failed to acquire swap devices: %v\n", err)
+		return
+	}
+
+	m := web.JSONResponseMessage{}
+	if err := json.Unmarshal(resp, &m); err != nil {
+		fmt.Printf("Failed to decode json message: %v\n", err)
+		return
+	}
+
+	if !m.Success {
+		fmt.Printf("Failed to acquire swap devices: %v\n", m.Errors)
+		return
+	}
+
+	jsonData, err := json.Marshal(m.Message)
+	if err != nil {
+		fmt.Printf("Error: %s", err.Error())
+	} else {
+		fmt.Printf("%v\n", color.HiBlueString(string(jsonData)))
+	}
+}


### PR DESCRIPTION
```
❯ sudo bin/pmctl status proc swap-devices | jq
[
  {
    "freeBytes": 2197811200,
    "name": "/dev/dm-1",
    "usedBytes": 0
  },
  {
    "freeBytes": 8589930496,
    "name": "/dev/zram0",
    "usedBytes": 0
  }
]

```